### PR TITLE
Added H1 H2 H3 tags feature along with p tag flexibility

### DIFF
--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -90,6 +90,17 @@ export class NewBoardComponent implements OnInit {
                       </svg>
                     </button>
                   </div>
+                  <!-- paragraph -->
+                  <div class="tool box4 m-1">
+                    <button class="btn btn-light" id="add-p-box2-${uid}">
+                      <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-text-paragraph" fill="currentColor"
+                        xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd"
+                          d="M2 12.5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5zm0-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5zm4-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5z" />
+                      </svg>
+                    </button>
+                  </div>
+
                 </div>
               </div>
             </div>
@@ -165,6 +176,17 @@ export class NewBoardComponent implements OnInit {
                     </svg>
                   </button>
                 </div>
+                <!-- paragraph -->
+                <div class="tool box4 m-1">
+                  <button class="btn btn-light" id="add-p-box2-${uid}">
+                    <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-text-paragraph" fill="currentColor"
+                      xmlns="http://www.w3.org/2000/svg">
+                      <path fill-rule="evenodd"
+                        d="M2 12.5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5zm0-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5zm4-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5z" />
+                    </svg>
+                  </button>
+                </div>
+
               </div>
             </div>
           </div>
@@ -200,6 +222,11 @@ export class NewBoardComponent implements OnInit {
   //Adding H3 Tags
   $(`#add-h3-box2-${uid}`).click( () => {
     $(`#cb-box-2-${uid}`).removeClass("cb-H1 cb-H2").addClass("cb-H3")
+  })
+
+  //Adding Paragraphs
+  $(`#add-p-box2-${uid}`).click( () => {
+    $(`#cb-box-2-${uid}`).removeClass("cb-H1 cb-H2 cb-H3")
   })
 
     }catch(error){


### PR DESCRIPTION
**Fixes:** #21

**Introduced changes**
A User can now add H1 H2 H3 tags feature along with p tag flexibility in creative board. 

**Image of the feature**
![image](https://user-images.githubusercontent.com/32712438/92993723-856d3f80-f511-11ea-9d1a-8a6e3348d4c2.png)
![image](https://user-images.githubusercontent.com/32712438/92993729-91f19800-f511-11ea-99bf-7618b6010351.png)
![image](https://user-images.githubusercontent.com/32712438/92993733-9a49d300-f511-11ea-9fa2-11f81a59fa73.png)
![image](https://user-images.githubusercontent.com/32712438/92993739-ae8dd000-f511-11ea-892c-bead589668bf.png)
