### PR TITLE
style: add mobile layout fixes

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -4,9 +4,9 @@
       <img src="../../../assets/home/logo_bw.png" width="100" alt="Logo">
     </div>
   </div>
-  <div class="row mt-3">
+  <div class="row">
     <div class="links">
-      <ul>
+      <ul class="row justify-content-center mt-3">
         <li><a href="#">Home</a></li>
         <li><a href="https://github.com/Canvasbird/canvasboard">Github</a></li>
         <li><a href="#">Documentation</a></li>
@@ -14,12 +14,12 @@
       </ul>
     </div>
   </div>
-  <div class="row justify-content-md-center mt-4">
-    <div class="col-8 col-sm-8 text-center">
+  <div class="row justify-content-center mt-4">
+    <div class="text-center">
       <p class="header">Canvasboard</p>
     </div>
   </div>
-  <div class="row justify-content-md-center">
+  <div class="row justify-content-center">
     <div class="col-10 col-sm-10 text-center">
       <p class="sub-header">An interactive <span class="webboard">webboard</span> for <span
           class="Schools">Schools</span>, <span class="Colleges">Colleges</span> and <span
@@ -27,8 +27,8 @@
     </div>
   </div>
   <div class="row mt-4 mb-4 justify-content-md-center">
-    <div class="col-10 col-sm-10 text-center mx-auto">
-      <img src="../../../assets/home/board.png" alt="board" class="board">
+    <div class="col-12 col-sm-10 text-center mx-auto">
+      <img src="../../../assets/home/board.png" alt="board" class="board mt-2 mb-5 shadow rounded">
     </div>
   </div>
 </div>

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -18,17 +18,29 @@
       text-align: center;
       margin-left: 1rem;
       margin-right: 1rem;
+      padding-top: 0.5rem;
     }
   }
+
   .header{
     font-family: 'Poppins', sans-serif;
     font-weight: 500;
-    font-size: 60px;
+    font-size: 42px;
+
+    @media (min-width: 768px) {
+        font-size: 60px;
+    }
   }
+
+
   .sub-header{
     font-family: 'Questrial', sans-serif;
-    font-size: 30px;
+    font-size: 24px;
     line-height: 31px;
+
+    @media (min-width: 768px) {
+      font-size: 30px;
+  }
     .webboard{
       color: #EE6D9E;
       font-weight: bold;


### PR DESCRIPTION
Fixes #73

## Issue that this pull request solves

 Closes: # 73

## Proposed changes

- Navigation now wraps on smaller breakpoints
- Text is centered and resized down on mobile
- Took a tiny bit of liberty and improved the design by giving the image more space, and added a drop shadow to have it pop off the page more

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [X] Other (please describe): Style updates on homepage, in particular on mobile

## Checklist

_Put an `x` in the boxes that apply_

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] My changes does not break the current system and it passes all the current test cases.

## Screenshots

![Screen Shot 2020-10-03 at 10 58 10](https://user-images.githubusercontent.com/25023919/94989886-66d5f380-0567-11eb-958d-99bdbfce24bf.png)

