### PR TITLE
Add playfair font as a plugin

### DIFF
--- a/src/app/components/new-board/new-board.component.html
+++ b/src/app/components/new-board/new-board.component.html
@@ -104,7 +104,7 @@
           </div>
           <!-- Playfair -->
           <div class="m-1">
-            <button class="btn btn-light">
+            <button class="btn btn-light playfair" (click)="cbToolboxPlayfair()">
               Playfair
             </button>
           </div>

--- a/src/app/components/new-board/new-board.component.scss
+++ b/src/app/components/new-board/new-board.component.scss
@@ -178,3 +178,7 @@
   font-family: 'Courier Prime', monospace;
 }
 
+.playfair {
+  font-family: 'Playfair Display', serif;
+}
+

--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -260,7 +260,6 @@ export class NewBoardComponent implements OnInit {
         );
         this.AddFontMonospaceComponent.addMonospaceFontToolBox(uid)
       }
-      console.log({checker})
       if(checker === 12) {
         $(`#${id}`).append(
           this.blockFunction(uid)

--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -13,6 +13,7 @@ import {AddH3Component} from '../../plugins/cb-h3'
 import {AddParaComponent} from '../../plugins/cb-p'
 import {AddRedBackgroundComponent} from '../../plugins/color-background/cb-redbackground'
 import {AddFontMonospaceComponent} from '../../plugins/monospace'
+import {AddFontPlayfairComponent} from "../../plugins/playfair"
 
 declare var $: any;
 
@@ -35,6 +36,7 @@ export class NewBoardComponent implements OnInit {
   AddRedBackgroundComponent:any;
   AddCanvasBoard:any;
   AddFontMonospaceComponent:any;
+  AddFontPlayfairComponent:any;
 
   uniqueChartID = (function() {
     var id = 0;
@@ -49,6 +51,7 @@ export class NewBoardComponent implements OnInit {
     this.AddRedBackgroundComponent = new AddRedBackgroundComponent()
     this.AddCanvasBoard = new AddCanvasBoard()
     this.AddFontMonospaceComponent = new AddFontMonospaceComponent()
+    this.AddFontPlayfairComponent = new AddFontPlayfairComponent()
   }
 
   ngOnInit() {
@@ -256,6 +259,13 @@ export class NewBoardComponent implements OnInit {
           this.blockFunction(uid)
         );
         this.AddFontMonospaceComponent.addMonospaceFontToolBox(uid)
+      }
+      console.log({checker})
+      if(checker === 12) {
+        $(`#${id}`).append(
+          this.blockFunction(uid)
+        );
+        this.AddFontPlayfairComponent.addPlayfairFontToolBox(uid)
       }
 
       // hiding and showing the TOOLBOX
@@ -917,6 +927,11 @@ export class NewBoardComponent implements OnInit {
   // Adding Monoscpace font
   cbToolboxMonospace = () => {
     this.addAfterBlockEditor('main-box',11);
+  }
+
+  // Adding Playfair font
+  cbToolboxPlayfair = () => {
+    this.addAfterBlockEditor('main-box',12);
   }
 
 }

--- a/src/app/plugins/playfair.ts
+++ b/src/app/plugins/playfair.ts
@@ -1,0 +1,9 @@
+declare var $: any;
+
+export class AddFontPlayfairComponent {
+  constructor() {}
+
+  addPlayfairFontToolBox = (uid) => {
+    $(`#cb-box-2-${uid}`).addClass("playfair-font");
+  };
+}

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Alegreya:wght@500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600&display=swap" rel="stylesheet">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -83,6 +83,10 @@
 .monospace-font {
   font-family: 'Courier Prime', monospace;
 }
+.playfair-font {
+  font-family: 'Playfair Display', serif;
+}
+
 // Board
 .cb-more-toolbox{
   position: relative;


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #113 

## Proposed changes

Added Playfair font as plugin

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (there was not really anything)
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases. - Not sure about this point since there are some fial

## Screenshots

![image](https://user-images.githubusercontent.com/16169571/95633074-34f0ef80-0a87-11eb-8974-cd9646996466.png)


## Other information

Any other information that is important to this pull request
