### PR TITLE
Remove forgot password from sign up page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,7 +12,6 @@ import { AssignmentComponent } from './components/assignment/assignment.componen
 // guard
 import { AuthGuard } from './shared/auth.guard';
 import { NewBoardComponent } from './components/new-board/new-board.component';
-import { UserDashboardComponent } from './components/user-dashboard/user-dashboard.component';
 import { ContributionComponent } from './components/contribution/contribution.component';
 import { FilesComponent } from './components/files/files.component';
 const routes: Routes = [

--- a/src/app/components/board/board.component.html
+++ b/src/app/components/board/board.component.html
@@ -216,7 +216,7 @@
       <li class="finalBtn">
         <div class="btx">
           <button class="btn btn-success btn-save" (click)="downloadAsJSON()">Save</button>
-          <button class="btn btn-danger btn-exit">Exit</button>
+          <button class="btn btn-danger btn-exit" (click)="exitPage()">Exit</button>
         </div>
       </li>
     </ul>

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -2,15 +2,18 @@ import { Component, OnInit, ViewChild, HostListener, Renderer2 } from '@angular/
 import { Pages } from '../../../interfaces/pages';
 import { Tracking } from '../../../interfaces/tracking';
 import { log } from 'util';
+import {Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
+
 declare const pdfjsLib: any;
 @Component({
   selector: 'app-board',
   templateUrl: './board.component.html',
-  styleUrls: ['./board.component.scss']
+  styleUrls: ['./board.component.scss'],
+  providers: [Location, {provide: LocationStrategy, useClass: PathLocationStrategy}]
 })
 export class BoardComponent implements OnInit {
 
-  constructor(public renderer: Renderer2) {
+  constructor(public renderer: Renderer2, private location: Location) {
     this.getScreenSize();
   }
 
@@ -580,7 +583,11 @@ export class BoardComponent implements OnInit {
     a.click();
     document.body.removeChild(a);
   }
-  //
+
+  exitPage() {
+    this.location.back();
+  }
+
   addClearBackground() {
     let ctx: any = document.getElementById('backgroundImage');
     if (ctx.getContext) {

--- a/src/app/components/sign-up/sign-up.component.html
+++ b/src/app/components/sign-up/sign-up.component.html
@@ -14,11 +14,6 @@
           <input type="text" class="form-control" id="inputUsername" placeholder="Enter Username" [(ngModel)]="userName" [ngModelOptions]="{standalone: true}">
         </div>
         <div class="form-group">
-          <label for="exampleInputInstitute"><strong>Institute Name</strong></label>
-          <input type="text" class="form-control" id="exampleInputInstitute" aria-describedby="instituteHelp" placeholder="Enter Institute" [(ngModel)]="instituteName" [ngModelOptions]="{standalone: true}">
-          <small id="instituteHelp" class="form-text text-muted">Optional</small>
-        </div>
-        <div class="form-group">
           <label for="exampleInputEmail1"><strong>Email address</strong></label>
           <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter email" [(ngModel)]="email" [ngModelOptions]="{standalone: true}">
           <small id="emailHelp" class="form-text text-muted">We'll never share your email with anyone else.</small>

--- a/src/app/components/sign-up/sign-up.component.html
+++ b/src/app/components/sign-up/sign-up.component.html
@@ -28,9 +28,9 @@
           <input type="password" class="form-control" id="exampleInputPassword1" aria-describedby="passwordHelp" placeholder="Password" [(ngModel)]="password" [ngModelOptions]="{standalone: true}">
           <small id="passwordHelp" class="form-text text-muted">Min 6 characters</small>
         </div>
-        <div class="form-group">
+        <!-- <div class="form-group">
           <a>Forgot Password?</a>
-        </div>
+        </div> -->
         <div class="form-group">
           <button type="button" class="btn-grad btn-outline-dark" (click)="signUp()"><strong style="padding:10px">Sign Up</strong></button>
           <p style="font-size: 15px;">Already have an account?</p>


### PR DESCRIPTION
## This PR removes the forgot password from the sign up page .

## Closes Issue no. -- #213 and #214 

## Proposed changes : To remove the forgot password from the sign up page.

### Brief description of what is fixed or changed : The forgot password has been removed from the sign up page as it was no longer needed.

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ x ] Other (please describe): Removed forgot password from sign up page 

## Checklist

_Put an `x` in the boxes that apply_

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

![canvas-signup](https://user-images.githubusercontent.com/54373853/99912440-af1ac200-2d1d-11eb-8e9e-8209c2bc4895.png)


## Other information

#### Please mention if any other changes are needed.
