### PR TITLE
Added LoginGuard to automatically redirect authorized users to dashboard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,7 +10,7 @@ import { BoardComponent } from './components/board/board.component';
 import { AssignmentComponent } from './components/assignment/assignment.component';
 
 // guard
-import { AuthGuard } from './shared/auth.guard';
+import { AuthGuard, LoginGuard } from './shared/auth.guard';
 import { NewBoardComponent } from './components/new-board/new-board.component';
 import { ContributionComponent } from './components/contribution/contribution.component';
 import { FilesComponent } from './components/files/files.component';
@@ -22,15 +22,18 @@ const routes: Routes = [
   },
   {
     path: 'home',
-    component: HomeComponent
+    component: HomeComponent,
+    canActivate: [LoginGuard]
   },
   {
     path: 'login',
-    component: LoginComponent
+    component: LoginComponent,
+    canActivate: [LoginGuard]
   },
   {
     path: 'sign-up',
-    component: SignUpComponent
+    component: SignUpComponent,
+    canActivate: [LoginGuard]
   },
   {
     path: 'contribution',

--- a/src/app/shared/auth.guard.spec.ts
+++ b/src/app/shared/auth.guard.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, inject } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { AuthGuard } from './auth.guard';
+import { AuthGuard, LoginGuard } from './auth.guard';
 
 describe('AuthGuard', () => {
   beforeEach(() => {
@@ -13,6 +13,19 @@ describe('AuthGuard', () => {
   });
 
   it('should ...', inject([AuthGuard], (guard: AuthGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});
+
+describe('LoginGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ LoginGuard ],
+      imports: [ RouterTestingModule, HttpClientTestingModule ]
+    });
+  });
+
+  it('should ...', inject([LoginGuard], (guard: LoginGuard) => {
     expect(guard).toBeTruthy();
   }));
 });

--- a/src/app/shared/auth.guard.ts
+++ b/src/app/shared/auth.guard.ts
@@ -21,3 +21,24 @@ export class AuthGuard implements CanActivate {
   }
 
 }
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoginGuard implements CanActivate {
+
+  constructor(private authService: AuthService, public router: Router) {
+  }
+
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (!this.authService.isUserLoggedIn()) {
+      return true;
+    } else {
+      this.router.navigate(['dashboard']);
+      return false;
+    }
+  }
+
+}


### PR DESCRIPTION
## Issue that this pull request solves

Closes: #221 

## Proposed changes
Automatically redirect logged-in users from routes 'home', 'login', and 'sign-up' to dashboard.

### Brief description of what is fixed or changed
Added a LoginGuard class to auth.guard,
Added a spec for it (modelled on the existing AuthGuard spec), and
Edited routing module to make use of it for the aforementioned routes.

## Types of changes

_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
