### PR TITLE
Fixed the css bug in edit name functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "husky": {
   "hooks": {
     "pre-commit": "ng lint",
-    "pre-push": "ng test --no-watch"
+    "pre-push":"ng test --no-watch"
   }
 }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "typescript": "~3.5.3"
   },
   "husky": {
-    "hooks": {
-      "pre-commit": "ng lint",
-      "pre-push": "ng test --no-watch"
-    }
+  "hooks": {
+    "pre-commit": "ng lint",
+    "pre-push": "ng test --no-watch"
   }
+}
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "typescript": "~3.5.3"
   },
   "husky": {
-  "hooks": {
-    "pre-commit": "ng lint",
-    "pre-push":"ng test --no-watch"
+    "hooks": {
+      "pre-commit": "ng lint",
+      "pre-push": "ng test --no-watch"
+    }
   }
-}
 }

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -53,12 +53,13 @@ export class DashboardComponent implements OnInit {
           <button class="btn btn-outline-danger">Sure?</button>
         </div>
       </div>
-      <span id=edit-name-input-${obj._id} style="display:none">
-        <input class="folder-title" style="border:none; outline: none; border-radius:10em"id=new-name-text-${obj._id}
+      <div id=edit-name-input-${obj._id} style="display:none">
+        <input class="folder-title" style="border-color:transparent;width:55%;outline:none; border-radius:10em" id=new-name-text-${obj._id}
         value="${obj.folder_name}" type="text">
+        <div style="display:inline-block;">
         <button style="border-style:none; outline: none; background-color:transparent" id=button-edit-name-ok-${obj._id}>
-          <svg  width="2em" height="2em"  xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 550 550">
+          <svg  width="1.5em" height="1.5em"  xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 500 500">
             <circle style="fill:#32BA7C;" cx="253.6" cy="253.6" r="253.6"/>
             <path style="fill:#0AA06E;" d="M188.8,368l130.4,130.4c108-28.8,188-127.2,188-244.8c0-2.4,0-4.8,0-7.2L404.8,152L188.8,368z"/>
               <path style="fill:#FFFFFF;" d="M260,310.4c11.2,11.2,11.2,30.4,0,41.6l-23.2,23.2c-11.2,11.2-30.4,11.2-41.6,0L93.6,272.8
@@ -68,8 +69,8 @@ export class DashboardComponent implements OnInit {
           </svg>
         </button>
         <button style="border-style:none; outline: none; background-color:transparent" id=button-edit-name-no-${obj._id}>
-          <svg  width="2em" height="2em"  xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 500 500">
+          <svg  width="1.5em" height="1.5em"  xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 450 450">
             <circle style="fill:#E24C4B;" cx="227.556" cy="227.556" r="227.556"/>
             <path style="fill:#D1403F;" d="M455.111,227.556c0,125.156-102.4,227.556-227.556,227.556c-72.533,0-136.533-32.711-177.778-85.333
               c38.4,31.289,88.178,49.778,142.222,49.778c125.156,0,227.556-102.4,227.556-227.556c0-54.044-18.489-103.822-49.778-142.222
@@ -80,8 +81,9 @@ export class DashboardComponent implements OnInit {
               c8.533-8.533,22.756-8.533,31.289,0c8.533,8.533,8.533,22.756,0,31.289l-72.533,72.533l72.533,72.533
               C339.911,308.622,339.911,322.844,331.378,331.378z"/>
           </svg>
-        </button>
-      </span>
+          </button>
+        </div>
+        </div>
       <h5 class="folder-title" id=folder-name-${obj._id}>
         <strong id=name-display-${obj._id}>${obj.folder_name}</strong>
         <button style="border-style:none; color:rgb(99, 64, 88); outline: none; margin-left:10px;background-color:transparent"
@@ -124,16 +126,24 @@ export class DashboardComponent implements OnInit {
           editText.style.display = 'none';
           folderName.style.display = 'block';
         }
+        if (document.getElementById(`new-name-text-${obj._id}`).style.borderColor === 'red') {
+          document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'transparent';
+        }
       });
     // Click action to save the new edited name
       $(`#button-edit-name-ok-${obj._id}`).click( () => {
         const newName = (document.getElementById(`new-name-text-${obj._id}`) as HTMLInputElement).value;
         const folderName = document.getElementById(`folder-name-${obj._id}`);
         const editText = document.getElementById(`edit-name-input-${obj._id}`);
-        this.renameFolder(obj, newName);
-        if (editText.style.display === 'block') {
-          editText.style.display = 'none';
-          folderName.style.display = 'block';
+        if (newName === '') {      // If the new name is null then do not change the name.
+          document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'red';
+        } else {
+          document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'transparent';
+          this.renameFolder(obj, newName);
+          if (editText.style.display === 'block') {
+            editText.style.display = 'none';
+            folderName.style.display = 'block';
+          }
         }
       });
     // Open delete popup
@@ -204,12 +214,13 @@ export class DashboardComponent implements OnInit {
         <button class="btn btn-outline-danger">Sure?</button>
       </div>
     </div>
-    <span id=edit-name-input-${obj._id} style="display:none">
-        <input class="folder-title" style="border:none; outline: none; border-radius:10em"id=new-name-text-${obj._id}
+      <div id=edit-name-input-${obj._id} style="display:none">
+      <input class="folder-title" style="border-color:transparent;width:55%;outline:none; border-radius:10em" id=new-name-text-${obj._id}
         value="${obj.folder_name}" type="text">
+        <div style="display:inline-block;">
         <button style="border-style:none; outline: none; background-color:transparent" id=button-edit-name-ok-${obj._id}>
-          <svg  width="2em" height="2em"  xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 550 550">
+          <svg  width="1.5em" height="1.5em"  xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 500 500">
             <circle style="fill:#32BA7C;" cx="253.6" cy="253.6" r="253.6"/>
             <path style="fill:#0AA06E;" d="M188.8,368l130.4,130.4c108-28.8,188-127.2,188-244.8c0-2.4,0-4.8,0-7.2L404.8,152L188.8,368z"/>
               <path style="fill:#FFFFFF;" d="M260,310.4c11.2,11.2,11.2,30.4,0,41.6l-23.2,23.2c-11.2,11.2-30.4,11.2-41.6,0L93.6,272.8
@@ -219,8 +230,8 @@ export class DashboardComponent implements OnInit {
           </svg>
         </button>
         <button style="border-style:none; outline: none; background-color:transparent" id=button-edit-name-no-${obj._id}>
-          <svg  width="2em" height="2em"  xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 500 500">
+          <svg  width="1.5em" height="1.5em"  xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 450 450">
             <circle style="fill:#E24C4B;" cx="227.556" cy="227.556" r="227.556"/>
             <path style="fill:#D1403F;" d="M455.111,227.556c0,125.156-102.4,227.556-227.556,227.556c-72.533,0-136.533-32.711-177.778-85.333
               c38.4,31.289,88.178,49.778,142.222,49.778c125.156,0,227.556-102.4,227.556-227.556c0-54.044-18.489-103.822-49.778-142.222
@@ -231,8 +242,9 @@ export class DashboardComponent implements OnInit {
               c8.533-8.533,22.756-8.533,31.289,0c8.533,8.533,8.533,22.756,0,31.289l-72.533,72.533l72.533,72.533
               C339.911,308.622,339.911,322.844,331.378,331.378z"/>
           </svg>
-        </button>
-      </span>
+          </button>
+        </div>
+      </div>
       <h5 class="folder-title" id=folder-name-${obj._id}>
         <strong id=name-display-${obj._id}>${obj.folder_name}</strong>
         <button style="border-style:none; color:rgb(99, 64, 88); outline: none; margin-left:10px;background-color:transparent"
@@ -268,7 +280,7 @@ export class DashboardComponent implements OnInit {
       }
     });
 
-    // Click action to close the edited input
+    // Click action to close the edit input
     $(`#button-edit-name-no-${obj._id}`).click( () => {
       const folderName = document.getElementById(`folder-name-${obj._id}`);
       const editText = document.getElementById(`edit-name-input-${obj._id}`);
@@ -276,18 +288,28 @@ export class DashboardComponent implements OnInit {
         editText.style.display = 'none';
         folderName.style.display = 'block';
       }
+      if (document.getElementById(`new-name-text-${obj._id}`).style.borderColor === 'red') {
+        document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'transparent';
+      }
     });
     // Click action to save the new edited name
     $(`#button-edit-name-ok-${obj._id}`).click( () => {
       const newName = (document.getElementById(`new-name-text-${obj._id}`) as HTMLInputElement).value;
       const folderName = document.getElementById(`folder-name-${obj._id}`);
       const editText = document.getElementById(`edit-name-input-${obj._id}`);
-      this.renameFolder(obj, newName);
-      if (editText.style.display === 'block') {
-        editText.style.display = 'none';
-        folderName.style.display = 'block';
+      if (newName === '') {      // If the new name is null then do not change the name.
+        document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'red';
+      } else {
+        document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'transparent';
+        this.renameFolder(obj, newName);
+        if (editText.style.display === 'block') {
+          editText.style.display = 'none';
+          folderName.style.display = 'block';
+        }
       }
-    });    // Open delete popup
+    });
+
+    // Open delete popup
     $(`#delete-${obj._id}`).click( () => {
       const popup = document.getElementById(`delete-sure-${obj._id}`);
       if (popup.style.display === 'block') {

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -54,9 +54,12 @@ export class DashboardComponent implements OnInit {
         </div>
       </div>
       <div id=edit-name-input-${obj._id} style="display:none">
-        <input class="folder-title" style="border-color:transparent;width:55%;outline:none; border-radius:10em" id=new-name-text-${obj._id}
-        value="${obj.folder_name}" type="text">
-        <div style="display:inline-block;">
+      <input
+      class="folder-title" style= "margin-top:2.7em; margin-bottom:0.6em; border-color:transparent;
+      width:55%; outline:none; border-radius:10em"
+      id = new-name-text-${obj._id} value = "${obj.folder_name}" type="text"
+      >
+      <div style="display:inline-block;">
         <button style="border-style:none; outline: none; background-color:transparent" id=button-edit-name-ok-${obj._id}>
           <svg  width="1.5em" height="1.5em"  xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 500 500">
@@ -215,9 +218,12 @@ export class DashboardComponent implements OnInit {
       </div>
     </div>
       <div id=edit-name-input-${obj._id} style="display:none">
-      <input class="folder-title" style="border-color:transparent;width:55%;outline:none; border-radius:10em" id=new-name-text-${obj._id}
-        value="${obj.folder_name}" type="text">
-        <div style="display:inline-block;">
+      <input
+      class="folder-title" style= "margin-top:2.7em; margin-bottom:0.6em; border-color:transparent;
+      width:55%; outline:none; border-radius:10em"
+      id = new-name-text-${obj._id} value = "${obj.folder_name}" type="text"
+      >
+      <div style="display:inline-block;">
         <button style="border-style:none; outline: none; background-color:transparent" id=button-edit-name-ok-${obj._id}>
           <svg  width="1.5em" height="1.5em"  xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 500 500">


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #240

## Proposed changes
Rename CSS issue in responsive screens.  All the buttons in rename functionality should be in one single row

### Brief description of what is fixed or changed
The input tag, save button and the cancel button will now be in one single row.
The rename functionality will not be able to take null/void names.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
![Screenshot from 2020-12-12 08-52-09](https://user-images.githubusercontent.com/56181018/101971443-5d4bc480-3c57-11eb-89a7-7061e1ed1a3f.png)
![Screenshot from 2020-12-12 08-51-31](https://user-images.githubusercontent.com/56181018/101971445-5f158800-3c57-11eb-9c24-b13fbf6b2ff0.png)

## Other information

Any other information that is important to this pull request
