### PR TITLE
Add del key to board

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "typescript": "~3.5.3"
   },
   "husky": {
-    "hooks": {
-      "pre-commit": "ng lint",
-      "pre-push": "ng test --no-watch"
-    }
+  "hooks": {
+    "pre-commit": "ng lint",
+    "pre-push": "ng test --no-watch"
+  }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "husky": {
   "hooks": {
     "pre-commit": "ng lint",
-    "pre-push": "ng test --no-watch"
+    "pre-push":"ng test --no-watch"
   }
 }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "typescript": "~3.5.3"
   },
   "husky": {
-  "hooks": {
-    "pre-commit": "ng lint",
-    "pre-push":"ng test --no-watch"
+    "hooks": {
+      "pre-commit": "ng lint",
+      "pre-push": "ng test --no-watch"
+    }
   }
-}
 }

--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "pre-commit": "ng lint",
     "pre-push": "ng test --no-watch"
   }
-  }
+}
 }

--- a/src/app/plugins/cb-whiteboard.ts
+++ b/src/app/plugins/cb-whiteboard.ts
@@ -125,5 +125,16 @@ export class AddCanvasBoard {
       canvas.on('selection:cleared', () => {
         $(`#canvas-menu-box-delete-${uid}`).prop('disabled', true);
       });
+
+      // checks if there is an active object selected, if not null checks for a delete event and deletes it.
+      document.addEventListener('keydown', (event) => {
+        const key = event.key;
+        if (key === 'Delete') {
+          const shape = canvas.getActiveObject();
+          if (shape != null) {
+            canvas.remove(shape);
+          }
+        }
+      });
     }
 }


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #238 

## Proposed changes
Made the delete key functional when an active object is selected on the whiteboard.

### Brief description of what is fixed or changed
Added an event listener for the delete key, when an active object is selected on the whiteboard.
## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.



## Other information

Had to delete the previous pull request because made unnecessary changes in my forked master branch by mistake.
Thanks 
Ishan
