### PR TITLE
Make Toolbox responsive

### DIFF
--- a/src/app/components/new-board/new-board.component.scss
+++ b/src/app/components/new-board/new-board.component.scss
@@ -7,6 +7,7 @@
         padding-top: 1rem;
         padding-bottom: 10px;
         border-bottom: 2px solid #999999;
+        display: flex;
       }
 
       .heading:focus {
@@ -102,7 +103,8 @@
 }
 
 [contentEditable=true]:empty:not(:focus):before {
-  content: attr(data-text)
+  content: attr(data-text);
+  display: inline-flex;
 }
 
 .inline-flex {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -144,6 +144,10 @@
   .cbff-container {
     grid-template-columns: repeat(2,1fr);
   }
+  .toolbox-main{
+    width: calc(100vw - 80px);
+    overflow-x: scroll;
+  }
 }
 @media (max-width: 576px) {
   .cbff-container {


### PR DESCRIPTION
## Issue that this pull request solves - This PR solves the issue that the toolbox was not responsive in mobile view.

 ## Closes: #24 

## Proposed changes - To make the toolbox responsive and to make the title of the new board display inline.

### Brief description of what is fixed or changed - The toolbox is now scrollable, so all the elements of the toolbox are now visible.

## Types of changes - bug fixes

_Put an `x` in the boxes that apply_

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

https://user-images.githubusercontent.com/54373853/102713194-4a3a9380-42ec-11eb-91c9-47557670ace9.mp4


## Other information

Please mention if any other changes are required in the PR.
