### PR TITLE
Fixed searching renamed folder bug

### DIFF
--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -189,6 +189,7 @@ export class DashboardComponent implements OnInit {
             folderName.style.display = 'block';
             editButton.style.display = 'block';
           }
+          this.data.find(x => x._id === obj._id).folder_name = newName;   // Changing the folder name in data variable that we used.
         }
       });
       // Open delete popup
@@ -330,7 +331,7 @@ export class DashboardComponent implements OnInit {
     $(`#button-edit-name-${obj._id}`).click(() => {
       const folderName = document.getElementById(`folder-name-${obj._id}`);
       const editText = document.getElementById(`edit-name-input-${obj._id}`);
-      const editButton = document.getElementById(`#button-edit-name-${obj._id}`);
+      const editButton = document.getElementById(`button-edit-name-${obj._id}`);
       if (editText.style.display === 'block') {
         editText.style.display = 'none';
         folderName.style.display = 'block';
@@ -347,7 +348,7 @@ export class DashboardComponent implements OnInit {
     $(`#button-edit-name-no-${obj._id}`).click(() => {
       const folderName = document.getElementById(`folder-name-${obj._id}`);
       const editText = document.getElementById(`edit-name-input-${obj._id}`);
-      const editButton = document.getElementById(`#button-edit-name-${obj._id}`);
+      const editButton = document.getElementById(`button-edit-name-${obj._id}`);
       if (editText.style.display === 'block') {
         editText.style.display = 'none';
         folderName.style.display = 'block';
@@ -362,7 +363,7 @@ export class DashboardComponent implements OnInit {
       const newName = (document.getElementById(`new-name-text-${obj._id}`) as HTMLInputElement).value;
       const folderName = document.getElementById(`folder-name-${obj._id}`);
       const editText = document.getElementById(`edit-name-input-${obj._id}`);
-      const editButton = document.getElementById(`#button-edit-name-${obj._id}`);
+      const editButton = document.getElementById(`button-edit-name-${obj._id}`);
       if (newName === '') {      // If the new name is null then do not change the name.
         document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'red';
       } else {
@@ -373,6 +374,7 @@ export class DashboardComponent implements OnInit {
           folderName.style.display = 'block';
           editButton.style.display = 'block';
         }
+        this.data.find(x => x._id === obj._id).folder_name = newName;     // Changing the folder name in data variable that we used.
       }
     });
 

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -10,7 +10,7 @@ export class HomeComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit(){
+  ngOnInit() {
     AOS.init();
    }
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -11,7 +11,7 @@ export class AuthService {
   signUpLoad = false;
   signUpReqObj;
   signUpResObj;
-  
+
   loginLoad = false;
   loginReqObj;
   loginResObj;


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #303

## Proposed changes
Update the renamed folder name in the data variable that we are using for filtering. 

### Brief description of what is fixed or changed
When the user renames a folder, the folder now appears when it is searched.
Also, corrected few incorrect div ids in the dashboard component.

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
https://user-images.githubusercontent.com/56181018/104091617-838b7100-52a4-11eb-97ca-e6e7d33aaa75.mp4

## Other information

Any other information that is important to this pull request
