### PR TITLE
Made plus sign in the dashboard active

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -13,7 +13,8 @@
   <div class="cbff-container mt-4">
     <div class="new-folder">
       <br>
-      <svg width="2em" height="2em" viewBox="0 0 16 16" class="bi bi-plus-circle" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <svg data-toggle="modal" data-target="#newCard" width="2em" height="2em" viewBox="0 0 16 16" class="bi bi-plus-circle"
+       fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
         <path fill-rule="evenodd" d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
       </svg>

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -177,3 +177,12 @@
   white-space: normal;
   text-overflow: clip;
 }
+
+.bi-plus-circle{
+  transition: 0.3s;
+  fill:rgba(18, 16, 31, 0.603);
+}
+.bi-plus-circle:hover{
+  fill:rgb(0, 0, 0);
+  cursor:pointer;
+}


### PR DESCRIPTION
## Issue that this pull request solves
 Closes: #304

## Proposed changes
Made the plus sign in the dashboard active 

### Brief description of what is fixed or changed
Added a click action to the plus sign so that after clicking on that user can add new workspace.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

https://user-images.githubusercontent.com/56181018/107234555-ced2a400-6a49-11eb-831e-82ee08cf0711.mp4

