### PR TITLE
Updated the daily quote section - added padding, colour and right-quote img added

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -96,8 +96,8 @@
 
 <!-- Quote -->
 <footer class="quote mt-1 pb-0">
-  <span class="quoteText"><img src="https://img.icons8.com/fluent-systems-filled/24/000000/quote-left.png"/>{{quote?.text}}</span>
-  <span class="quoteAuthor">- {{quote?.author === "" ? 'Anonymous' : quote?.author}}</span>
+  <span class="quoteText"><img src="https://img.icons8.com/fluent-systems-filled/24/000000/quote-left.png"/>{{quote?.text}}<img src="https://img.icons8.com/fluent-systems-filled/24/000000/quote-right.png"/></span>
+  <span class="quoteAuthor pb-4">- {{quote?.author === "" ? 'Anonymous' : quote?.author}}</span>
 </footer>
 
 

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -144,24 +144,24 @@
 }
 
 .quoteText{
-  color: black;
+  color: rgb(78, 4, 78);
   display: flex;
   justify-content: center;
   font-family: 'PT Serif', serif;
   font-style: italic;
   font-size: 16px;
   font-weight: bold;
-  opacity: 50%;
+  opacity: 80%;
 }
 
 .quoteAuthor{
-  color: black;
+  color: brown;
   display: flex;
   justify-content: center;
   font-family: 'PT Serif', serif;
   font-style: italic;
   font-size: 16px;
-  opacity: 50%;
+  opacity: 80%;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Fixed #373

## Issue that this pull request solves

 Closes: #373 

## Proposed changes
The proposed changes were:
* The daily quote should appear on the development server
* The quote should have a good bottom padding
* The quote text color should be a bit nicer and attractive
### Brief description of what is fixed or changed
Changes made are:
* Added right quote image to give the quote a better and complete look. Earlier there was just on img `<img src="https://img.icons8.com/fluent-systems-filled/24/000000/quote-left.png"/>`, so closed it with `<img src="https://img.icons8.com/fluent-systems-filled/24/000000/quote-right.png"/>`.
* Changed the opacity and colors of both `quoteText` and `quoteAuthor` to make it look more attractive.
* Added padding at the bottom of quote section.
 
## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

Final output looks like this:
![image](https://user-images.githubusercontent.com/47056243/109066636-57706600-7713-11eb-957f-29acee56ee39.png)
