### PR TITLE
Enter keyword is activated for saving the renamed string

### DIFF
--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -220,6 +220,12 @@ export class DashboardComponent implements OnInit {
           this.data.find(x => x._id === obj._id).folder_name = newName;   // Changing the folder name in data variable that we used.
         }
       });
+      // Enter keyword action to save edited name
+      $(`#edit-name-input-${obj._id}`).keyup((event: { keyCode: number; }) => {
+        if (event.keyCode === 13) {
+          $(`#button-edit-name-ok-${obj._id}`).click();
+        }
+      });
       // Open delete popup
       $(`#delete-${obj._id}`).click(() => {
         const popup = document.getElementById(`delete-sure-${obj._id}`);
@@ -412,6 +418,12 @@ export class DashboardComponent implements OnInit {
         document.getElementById(`new-name-text-${obj._id}`).style.borderColor = 'transparent';
       }
     });
+      // Enter keyword action to save edited name
+      $(`#edit-name-input-${obj._id}`).keyup((event: { keyCode: number; }) => {
+        if (event.keyCode === 13) {
+          $(`#button-edit-name-ok-${obj._id}`).click();
+        }
+      });
     // Click action to save the new edited name
     $(`#button-edit-name-ok-${obj._id}`).click(() => {
       const newName = (document.getElementById(`new-name-text-${obj._id}`) as HTMLInputElement).value;


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #390 

## Activate Enter keyword while editing workspace name


## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.


