### PR TITLE
fix slideshow bug, initialized slides after the content is loaded

### DIFF
--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -99,13 +99,7 @@ export class NewBoardComponent implements OnInit {
     this.AddTwitterComponent = new AddTwitterComponent();
     this.AddMarkDownComponent = new AddMarkDownComponent();
     this.reader = new FileReader();
-    this.deck = new Reveal({
-      plugins: [
-        Markdown,
-        Highlight
-      ],
-      hash: true
-    }) as Reveal;
+    this.deck;
 
   }
 
@@ -212,7 +206,8 @@ export class NewBoardComponent implements OnInit {
   }
   // ----------------------- Reveal JS Config -------------------------------
   ngAfterViewInit() {
-    Reveal.initialize(
+    this.deck = new Reveal($('#revealDiv'))
+    this.deck.initialize(
       {
         plugins: [
           Markdown,
@@ -226,7 +221,7 @@ export class NewBoardComponent implements OnInit {
         keyboardCondition: 'focused'
       }
     );
-    Reveal.configure({
+    this.deck.configure({
       keyboard: {
         27: () => {
           $('presentModal').hide();
@@ -958,9 +953,9 @@ export class NewBoardComponent implements OnInit {
         slides.append(section);
       }
     });
-    Reveal.sync();
-    Reveal.slide(0);
-    Reveal.toggleHelp(true);
+    this.deck.sync();
+    this.deck.slide(0);
+    this.deck.toggleHelp(true);
   }
   closeSlideMenu = () => {
     document.getElementById('menu').style.width = '0';


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #428 

## Proposed changes

### Brief description of what is fixed or changed

Assigned a empty this.deck and initialized with new Reveal object every time ngAfterView triggers, so it assigns relevant classes after every render

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
