### PR TITLE
Upgrade sweetalert2 dependency to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "canvasboard",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -50,7 +51,7 @@
         "rimraf": "^3.0.2",
         "rxjs": "~6.6.3",
         "sortablejs": "^1.13.0",
-        "sweetalert2": "^10.13.0",
+        "sweetalert2": "^11.0.0",
         "tslib": "^2.0.0",
         "uniqid": "^5.2.0",
         "zone.js": "~0.10.2"
@@ -16122,9 +16123,12 @@
       }
     },
     "node_modules/sweetalert2": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.13.0.tgz",
-      "integrity": "sha512-kF6Pnr7s7GDqVYRqqgyfxvG5vlUqfP+j+JF7oZ7DOs0/35jg6sTu8hyi6oD6Rb3fIKWIf1S9mCU7wR8iKa7dAA=="
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.1.7.tgz",
+      "integrity": "sha512-7MHQVtKCTORfA9e58g9ZOfT3X58DkSBtvoCQJnqSHobXXb5C7aB8Yg/tAccTFnefCUBU41PoStjXMkzG3bNeig==",
+      "funding": {
+        "url": "https://sweetalert2.github.io/#donations"
+      }
     },
     "node_modules/symbol-observable": {
       "version": "3.0.0",
@@ -32440,9 +32444,9 @@
       }
     },
     "sweetalert2": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.13.0.tgz",
-      "integrity": "sha512-kF6Pnr7s7GDqVYRqqgyfxvG5vlUqfP+j+JF7oZ7DOs0/35jg6sTu8hyi6oD6Rb3fIKWIf1S9mCU7wR8iKa7dAA=="
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.1.7.tgz",
+      "integrity": "sha512-7MHQVtKCTORfA9e58g9ZOfT3X58DkSBtvoCQJnqSHobXXb5C7aB8Yg/tAccTFnefCUBU41PoStjXMkzG3bNeig=="
     },
     "symbol-observable": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "~6.6.3",
     "sortablejs": "^1.13.0",
-    "sweetalert2": "^10.13.0",
+    "sweetalert2": "^11.0.0",
     "tslib": "^2.0.0",
     "uniqid": "^5.2.0",
     "zone.js": "~0.10.2"


### PR DESCRIPTION
Good day, author of @sweetalert2 here

### Brief description of what is fixed or changed

Upgrading the `sweetalert2` dependency to the latest version. 

Here are release notes for the major release https://github.com/sweetalert2/sweetalert2/releases/tag/v11.0.0
None of the breaking changes seem to be relevant to canvasboard's codebase.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.