### PR TITLE
Login and sign up will now continue on enter to improve flow

### DIFF
--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -42,6 +42,7 @@
                             placeholder="Password"
                             [(ngModel)]="password"
                             [ngModelOptions]="{ standalone: true }"
+                            (keyup.enter)="login()"
                         />
                     </div>
                     <div class="form-group">
@@ -52,7 +53,6 @@
                             type="button"
                             class="btn-grad btn-outline-dark"
                             (click)="login()"
-                            (keyup.enter)="login()"
                         >
                             <strong style="padding: 10px">Log In</strong>
                         </button>

--- a/src/app/components/sign-up/sign-up.component.html
+++ b/src/app/components/sign-up/sign-up.component.html
@@ -77,6 +77,7 @@
                             [ngModelOptions]="{ standalone: true }"
                             matTooltip="Must contain atleast 6 characters"
                             [matTooltipPosition]="position"
+                            (keyup.enter)="signUp()"
                         />
                         <div
                             toggle="#password-field"
@@ -108,7 +109,6 @@
                             type="button"
                             class="btn-grad btn-outline-dark"
                             (click)="signUp()"
-                            (keyup.enter)="signUp()"
                         >
                             <strong style="padding: 10px">Sign Up</strong>
                         </button>


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #452 

## Proposed changes
This allows you to press enter and login/signup instead of mousing to the button or pressing tab to get to the button

### Brief description of what is fixed or changed
Added `(keyup.enter)` events

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
N/A UI has not visibly changed

## Other information

Any other information that is important to this pull request

Feel free to add comment or ask any questions, if you would like something changed let me know
