### PR TITLE
Fixed unscrollable slide in presentation mode

### DIFF
--- a/src/app/components/new-board/new-board.component.scss
+++ b/src/app/components/new-board/new-board.component.scss
@@ -272,3 +272,7 @@
     background: #000;
     color: #fff;
 }
+
+.reveal .slides {
+    overflow-y: auto !important;
+}


### PR DESCRIPTION
## Issue that this pull request solves

Closes: #432 

## Proposed changes
Made changes in the new-board.component.scss file in the newboard component

### Brief description of what is fixed or changed
Added overflow-y property and set its value to auto along with important to the existing class which is '.reveal .slides' incoming from reveal.css

## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update (Documentation content changed)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
Please attach the screenshots of the changes made in case of change in user interface
![Screenshot (134)](https://user-images.githubusercontent.com/71957423/144722254-8621db5a-9dee-411f-9f8f-823c2b663b3e.png)

## Other information

Any other information that is important to this pull request
