### PR TITLE
Fixed On-Paste Title CSS

### DIFF
--- a/src/app/components/new-board/new-board.component.html
+++ b/src/app/components/new-board/new-board.component.html
@@ -895,13 +895,7 @@
                             type="button"
                             class="btn btn-primary"
                             data-dismiss="modal"
-                            (click)="
-                                cbToolbox(
-                                    this.AddEmbedComponent,
-                                    'embed',
-                                    embedURL.value
-                                )
-                            "
+                            (click)="cbEmbedURL()"
                         >
                             Enter
                         </button>

--- a/src/app/components/new-board/new-board.component.html
+++ b/src/app/components/new-board/new-board.component.html
@@ -31,7 +31,7 @@
 </div>
 
 <div id="content">
-    <span class="slide" style="display: none" title="Open Toolbox 🚀">
+    <div class="slide" title="Open Toolbox" style="position: fixed; z-index: 999; padding: 0.5rem 0.5rem; height:100vh; background-color: #e8e8e8; margin-top:0.3rem;" id="slide">
         <a (click)="openSlideMenu()">
             <svg
                 width="1.5em"
@@ -47,16 +47,16 @@
                 />
             </svg>
         </a>
-    </span>
+    </div>
 
     <div id="menu" class="nav shadow">
-        <!-- <a (click)="closeSlideMenu()" class="close" title="Close Toolbox 🚀">
+        <a (click)="closeSlideMenu()" class="close" title="Close Toolbox">
       <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor"
         xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd"
           d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
       </svg>
-    </a> -->
+    </a>
 
         <div class="cb-ul">
             <div class="header">

--- a/src/app/components/new-board/new-board.component.html
+++ b/src/app/components/new-board/new-board.component.html
@@ -31,7 +31,7 @@
 </div>
 
 <div id="content">
-    <div class="slide" title="Open Toolbox" style="position: fixed; z-index: 999; padding: 0.5rem 0.5rem; height:100vh; background-color: #e8e8e8; margin-top:0.3rem;" id="slide">
+    <div class="slide" title="Open Toolbox" id="slide">
         <a (click)="openSlideMenu()">
             <svg
                 width="1.5em"

--- a/src/app/components/new-board/new-board.component.scss
+++ b/src/app/components/new-board/new-board.component.scss
@@ -90,6 +90,15 @@
     outline: none;
 }
 
+.slide {
+  position: fixed;
+  z-index: 999;
+  padding: 0.5rem 0.5rem;
+  height:100vh;
+  background-color: #e8e8e8;
+  margin-top:0.3rem;
+}
+
 .red {
     background: red;
 }

--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -1140,14 +1140,25 @@ export class NewBoardComponent implements OnInit, AfterViewInit {
         });
     };
 
+    cbEmbedURL = () => {
+        var validate = /^(http(s)?:\/\/)?(www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/;
+        $('#embedURL').val().match(validate) ? this.addBlockEditor({
+            id: 'main-box',
+            pluginComponent: this.AddEmbedComponent,
+            embedUrl: $('#embedURL')
+                .val()
+        }) : alert('Please enter a valid URL');
+    }
+
     cbToolboxYoutube = () => {
-        this.addBlockEditor({
+        var validateYT = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
+        $('#youtubeEmbedURL').val().match(validateYT) ? this.addBlockEditor({
             id: 'main-box',
             pluginComponent: this.AddEmbedComponent,
             embedUrl: $('#youtubeEmbedURL')
                 .val()
                 .replace(/watch\?v=/gi, 'embed/'),
-        });
+        }) : alert('Please enter a valid YouTube URL');
     };
 
     cbToolboxClock = () => {

--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -169,6 +169,7 @@ export class NewBoardComponent implements OnInit, AfterViewInit {
     ngOnInit() {
         // ----------------------- SORTABLE JS -----------------------
         const mainEl = document.getElementById('main-box');
+        document.getElementById('slide').style.display = 'none';
 
         const sortable = new Sortable(mainEl, {
             handle: '.dragHandle',
@@ -874,6 +875,7 @@ export class NewBoardComponent implements OnInit, AfterViewInit {
 
     // ----------------------- Reveal JS ------------------------------------------
     openSlideMenu = () => {
+        document.getElementById('slide').style.display = 'none';
         document.getElementById('menu').style.width = '250px';
         const divsToHide = document.getElementsByClassName('slider'); // divsToHide is an array
 
@@ -1084,6 +1086,7 @@ export class NewBoardComponent implements OnInit, AfterViewInit {
         this.deck.toggleHelp(true);
     };
     closeSlideMenu = () => {
+        document.getElementById('slide').style.display = 'unset';
         document.getElementById('menu').style.width = '0';
         document.getElementById('content').style.marginLeft = '0';
         const divsToHide = document.getElementsByClassName('slider'); // divsToHide is an array

--- a/src/app/components/new-board/new-board.component.ts
+++ b/src/app/components/new-board/new-board.component.ts
@@ -167,6 +167,19 @@ export class NewBoardComponent implements OnInit, AfterViewInit {
     public activeIndex = 0;
 
     ngOnInit() {
+        // ---------------------- Remove CSS for pasted text in title -----------------------
+        var myElement = document.getElementById('cb-title');
+        myElement.onpaste = function(e) {
+        var pastedText = undefined;
+        if ((window as any).clipboardData && (window as any).clipboardData.getData) { // IE
+            pastedText = (window as any).clipboardData.getData('Text');
+        } else if (e.clipboardData && e.clipboardData.getData) {
+            pastedText = e.clipboardData.getData('text/plain');
+        }
+        document.execCommand('insertText', false, pastedText); // Process and handle text...
+        return false; // Prevent the default handler from running.
+        };
+
         // ----------------------- SORTABLE JS -----------------------
         const mainEl = document.getElementById('main-box');
         document.getElementById('slide').style.display = 'none';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -150,7 +150,7 @@ $canvasboard-theme: mat-light-theme(
     z-index: 1000;
     flex-direction: column;
     width: 215px;
-    height: 310px;
+    max-height: 310px;
     overflow: scroll;
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
     scrollbar-width: none;  /* Firefox */


### PR DESCRIPTION
## Issue that this pull request solves

Closes: #470

## Proposed changes

Added an 'onpaste' event on the id 'cb-title' element and then retrieving on the plain text part from the copied clipboard text and then executing command 'insertText' to paste the text in the element.

## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update (Documentation content changed)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

https://user-images.githubusercontent.com/71957423/147415284-7479a826-4720-479d-a3b0-0ed9ab094c53.mp4